### PR TITLE
[FIX] 마이페이지 경력 및 활동이력, 프로젝트 리스트 페이지 칩

### DIFF
--- a/src/mypage/MyPage.tsx
+++ b/src/mypage/MyPage.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 const TabContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  width: 90%;
+  width: 75%;
   margin-bottom: clamp(3rem, 5vw, 5rem);
 `
 

--- a/src/mypage/component/HistoryItem.tsx
+++ b/src/mypage/component/HistoryItem.tsx
@@ -1,7 +1,7 @@
 // 2024-11-18 18:09 승균 작성
 import React from 'react';
 import styled from 'styled-components';
-import { ItemHeader, ItemTitle, ItemCategory, Divider, ItemPeriod, ItemDescription } from '../styles/PersonalHistory.styles';
+import { ItemHeader, ItemTitle, ItemCategory, ItemPeriod, ItemDescription } from '../styles/PersonalHistory.styles';
 import { HistoryItemType } from '../types/history.types';
 
 const ItemContainer = styled.div`
@@ -23,9 +23,8 @@ const HistoryItem = ({ item }: HistoryItemProps) => {
   return (
     <ItemContainer>
       <ItemHeader>
-        <ItemTitle>{item.title}</ItemTitle>
         <ItemCategory>{item.category}</ItemCategory>
-        <Divider>|</Divider>
+        <ItemTitle>{item.title}</ItemTitle>
         <ItemPeriod>{item.period}</ItemPeriod>
       </ItemHeader>
       {item.description && <ItemDescription>{item.description}</ItemDescription>}

--- a/src/mypage/component/HistorySection.tsx
+++ b/src/mypage/component/HistorySection.tsx
@@ -1,5 +1,5 @@
 // 2024-11-18 18:09 승균 작성
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { HistorySection as Section, HistoryTitle, HistoryContent } from '../styles/PersonalHistory.styles';
 import HistoryItem from './HistoryItem';
 import { HistoryItemType } from '../types/history.types';
@@ -7,13 +7,15 @@ import { HistoryItemType } from '../types/history.types';
 interface HistorySectionProps {
   title: string;
   items: HistoryItemType[];
+  children?: ReactNode;
 }
 
-const HistorySection = ({ title, items }: HistorySectionProps) => {
+const HistorySection = ({ title, items, children }: HistorySectionProps) => {
   return (
     <Section>
       <HistoryTitle>{title}</HistoryTitle>
       <HistoryContent>
+        {children}
         {items.map((item, index) => (
           <HistoryItem key={index} item={item} />
         ))}

--- a/src/mypage/component/ProfileHeader.tsx
+++ b/src/mypage/component/ProfileHeader.tsx
@@ -6,7 +6,7 @@ import { PiSirenThin } from "react-icons/pi";
 
 const ProfileContainer = styled.div`
   display: flex;
-  width: 100%;
+  width: 75%;
   gap: clamp(20px, 3vw, 40px);
   min-height: clamp(250px, 30vw, 400px);
   margin-bottom: 60px;

--- a/src/mypage/data/dummyData.ts
+++ b/src/mypage/data/dummyData.ts
@@ -2,6 +2,11 @@
 import { HistoryDataType } from '../types/history.types';
 
 export const dummyData: HistoryDataType = {
+    introduction: "안녕하세요, 저는 홍길동입니다.",
+    portfolio: [
+      "www.thisislinkreference.com",
+      "portfolio.pdf"
+    ],
     activities: [
       {
         title: "TS파트너즈 3기",
@@ -44,19 +49,22 @@ export const dummyData: HistoryDataType = {
     ],
     certification: [
       {
-        title: "2종보통 운전면허",
-        category: "",
-        period: "2022.06.~2023.01"
+        title: "해커톤 최우수상",
+        category: "수상",
+        period: "2022.06.~2023.01",
+        description: "세종창업지원 센터"
       },
       {
         title: "TOEIC SPEAKING IM2",
-        category: "",
-        period: "2022.06.~2023.01"
+        category: "어학",
+        period: "2022.06.~2023.01",
+        description: "YBM 어학시험"
       },
       {
         title: "GTQ 2급",
-        category: "",
-        period: "2022.06.~2023.01"
+        category: "자격/면허",
+        period: "2022.06.~2023.01",
+        description: "KPC자격"
       }
     ]
   };

--- a/src/mypage/page/PersonalHistory.tsx
+++ b/src/mypage/page/PersonalHistory.tsx
@@ -1,18 +1,52 @@
 // 2024-11-18 18:09 승균 작성
 import React, { useState } from 'react';
-import { HistoryContainer } from '../styles/PersonalHistory.styles';
+import styled from 'styled-components';
+import { HistoryContainer, Introduction, PortfolioItem, PortfolioLink } from '../styles/PersonalHistory.styles';
 import HistorySection from '../component/HistorySection';
 import { HistoryDataType } from '../types/history.types';
 import { dummyData } from '../data/dummyData';
+import { SignUpButton } from '../../login/style/LoginStyle';
+import { FaArrowRight } from 'react-icons/fa';
+
+const EditButton = styled(SignUpButton)`
+  margin-bottom: -3rem;
+`;
+
+const WithDrawButton = styled.a`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9E9E9E;
+  font-size: 1.2rem;
+  margin-bottom: 5rem;
+  text-decoration: underline;
+  cursor: pointer;
+`;
 
 const PersonalHistory = () => {
   const [historyData, setHistoryData] = useState<HistoryDataType>(dummyData);
 
   return (
     <HistoryContainer>
+      <HistorySection title="자기소개" items={[]}>
+        <Introduction>{historyData.introduction}</Introduction>
+      </HistorySection>
+
       <HistorySection title="경험 및 활동이력" items={historyData.activities} />
       <HistorySection title="경력" items={historyData.career} />
       <HistorySection title="자격증" items={historyData.certification} />
+
+      <HistorySection title="포트폴리오" items={[]}>
+        {historyData.portfolio.map((item, index) => (
+          <PortfolioItem key={index}>
+            {/* <PortfolioLink href={item}>{item}</PortfolioLink> // 포트폴리오 링크 추가 */}
+            <PortfolioLink>{item}</PortfolioLink>
+          </PortfolioItem>
+        ))}
+      </HistorySection>
+
+      <EditButton>로그인 정보 수정 <FaArrowRight /> </EditButton>
+      <WithDrawButton>회원탈퇴</WithDrawButton>
     </HistoryContainer>
   );
 };

--- a/src/mypage/styles/PersonalHistory.styles.ts
+++ b/src/mypage/styles/PersonalHistory.styles.ts
@@ -14,6 +14,23 @@ export const HistoryContainer = styled.div`
   }
 `;
 
+export const Introduction = styled.div`
+  color: white;
+  font-size: 1.2rem;
+  margin-bottom: 2rem;
+`;
+
+export const PortfolioItem = styled.div`
+  color: white;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+`;
+
+export const PortfolioLink = styled.div`
+  text-decoration: underline;
+  color: white;
+`;
+
 export const HistorySection = styled.div`
   display: flex;
   gap: clamp(40px, 4vw, 60px);
@@ -68,8 +85,8 @@ export const ItemHeader = styled.div`
 `;
 
 export const ItemCategory = styled.span`
-  color: #888;
-  font-size: clamp(17px, 1.5vw, 19px);
+  color: #E32929;
+  font-size: clamp(19px, 1.9vw, 23px);
   min-width: max-content;
 `;
 
@@ -85,6 +102,7 @@ export const ItemPeriod = styled.div`
   color: #888;
   font-size: clamp(17px, 1.5vw, 19px);
   min-width: max-content;
+  margin-left: auto;
 `;
 
 export const ItemTitle = styled.div`

--- a/src/mypage/types/history.types.ts
+++ b/src/mypage/types/history.types.ts
@@ -7,7 +7,9 @@ export type HistoryItemType = {
 };
 
 export type HistoryDataType = {
+  introduction: string;
   activities: HistoryItemType[];
   career: HistoryItemType[];
   certification: HistoryItemType[];
+  portfolio: string[];
 }; 

--- a/src/project/ProjectPage.tsx
+++ b/src/project/ProjectPage.tsx
@@ -66,8 +66,8 @@ const Navigation = styled.nav`
   padding: 1rem 0;
 `;
 
-const NavItem = styled.a`
-  color: white;
+const NavItem = styled.a<{ active?: boolean }>`
+  color: ${props => props.active ? '#white' : '#757575'};
   text-decoration: none;
   cursor: pointer;
 `;
@@ -87,12 +87,12 @@ const TagWrapper = styled.div`
 `;
 
 const Tag = styled.span<{ active?: boolean }>`
-  background: ${props => props.active ? '#E51D1D' : 'transparent'};
-  border: 1px solid ${props => props.active ? '#E51D1D' : 'white'};
-  color: white;
+  background: ${props => props.active ? 'none' : 'transparent'};
+  border: 2px solid ${props => props.active ? '#757575' : 'white'};
+  color: ${props => props.active ? '#757575' : 'white'};
   padding: 0.3rem 0.8rem;
   border-radius: 20px;
-  font-size: 0.9rem;
+  font-size: 1rem;
   cursor: pointer;
 `;
 
@@ -108,13 +108,14 @@ const SelectedTags = styled.div`
 
 const SelectedTag = styled.span`
   background: #E51D1D;
-  color: white;
-  padding: 0.2rem 0.7rem;
+  color: #212121;
+  padding: 0.4rem 0.7rem;
   border-radius: 20px;
-  font-size: 0.9rem;
+  font-size: 1rem;
   display: flex;
   align-items: center;
   gap: 0.2rem;
+  cursor: pointer;
   
   &::after {
     content: 'X';
@@ -162,6 +163,17 @@ const TotalProjects = styled.div`
   font-size: clamp(1rem, 1.2vw, 1.5rem);
 `;
 
+type TagCategory = '분야' | '기간' | '역할' | '필요스킬' | '회의' | '프로젝트단계';
+
+const tagOptions: Record<TagCategory, string[]> = {
+  분야: ['대회', '창업', '대외활동', '경험', '스터디'],
+  기간: ['1개월 이하', '1개월 ~ 3개월', '3개월 ~ 6개월', '6개월 ~ 1년', '1년 이상'],
+  역할: ['Front-end', 'Back-end', 'UXUI Design', 'BX Design', 'PM'],
+  필요스킬: ['Figma', 'Adobe Illustration', 'Adobe Photoshop', 'MidJourney', 'Tool'],
+  회의: ['오프라인', '온라인', '병행'],
+  프로젝트단계: ['시작 전', '기획 중', '디자인 중', '개발 중', '창업 중']
+};
+
 const ProjectPage: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -176,7 +188,9 @@ const ProjectPage: React.FC = () => {
     const matchesTags = selectedTags.length === 0 || 
                        selectedTags.some(tag => project.tags.includes(tag));
     
-    const matchesSearch = project.title.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesSearch = searchTerm
+      .split('')
+      .every(char => project.title.toLowerCase().includes(char.toLowerCase()));
 
     return matchesTags && matchesSearch;
   });
@@ -203,6 +217,14 @@ const ProjectPage: React.FC = () => {
     });
   };
 
+  const [activeCategory, setActiveCategory] = useState<TagCategory>('분야');
+  const [tags, setTags] = useState(tagOptions[activeCategory]);
+
+  const handleNavItemClick = (category: TagCategory) => {
+    setActiveCategory(category);
+    setTags(tagOptions[category]);
+  };
+
   return (
     <>
     <Header headerName="Project"/>
@@ -220,17 +242,16 @@ const ProjectPage: React.FC = () => {
       </SearchBar>
 
       <Navigation>
-        <NavItem>분야</NavItem>
-        <NavItem>기간</NavItem>
-        <NavItem>역할</NavItem>
-        <NavItem>리소스</NavItem>
-        <NavItem>회의</NavItem>
-        <NavItem>프로젝트 단계</NavItem>
+        {Object.keys(tagOptions).map(category => (
+          <NavItem key={category} onClick={() => handleNavItemClick(category as TagCategory)} active={activeCategory === category}>
+            {category}
+          </NavItem>
+        ))}
       </Navigation>
 
       <TagContainer>
         <TagWrapper>
-          {['대회', '창업', '대외활동', '경험', '스터디'].map(tag => (
+          {tags.map(tag => (
             <Tag 
               key={tag}
               active={selectedTags.includes(tag)}


### PR DESCRIPTION
[목적] ; 프로젝트 리스트 페이지 칩 수정 및 마이페이지 수정

[목표] : 칩 종류 수정, 경력 및 활동이력 탭 스타일 수정

[달성도] :
- 프로젝트 리스트 페이지 : 칩 종류 및 스타일 수정
- 마이페이지 
       - 전체 화면비율 figma에 맞추어 width : 75%로 변경
       - 경력 및 활동이력 탭에 자기소개와 포트폴리오 추가
       - 카테고리 색상 main색상으로 변경 및 기간정보 우측상단 정렬

[기타] :